### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ v 1.1.0 - ARC Support, CocoaPod specification
 
 2. Adding iCalObjCSDK to your project
 
-To use iCalForObj4 on your XCode project, you have to add the following files in [[https://github.com/cybergarage/iCal4ObjC/tree/master/iCalObjCSDK][iCalObjCSDK]] subfolder of the SDK package. 
+To use iCalForObj4 on your Xcode project, you have to add the following files in [[https://github.com/cybergarage/iCal4ObjC/tree/master/iCalObjCSDK][iCalObjCSDK]] subfolder of the SDK package. 
 
 <verbatim>
 CGICalendar.h


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
